### PR TITLE
Fix bug with fractional numbers not being lexed correctly.

### DIFF
--- a/lexer.grace
+++ b/lexer.grace
@@ -285,7 +285,7 @@ def LexerClass = object {
                                         tok := tokens.pop
                                         var decimal := makeNumToken(accum)
                                         if(decimal.base == 10) then {
-                                            tok := NumToken.new(tok.value ++ "." ++ decimal.value, 10)
+                                            tok := NumToken.new(tok.value ++ "." ++ accum, 10)
                                         } else {
                                             util.syntax_error("Fractional part of number must be in base 10.")
                                         }


### PR DESCRIPTION
Leading 0s in a fractional portion of a number were being ignored due to a change I made in 0ee04965. This has now been fixed and works as intended in 2b09462.
