### PR TITLE
Remove invalid syntax and improve error message.

### DIFF
--- a/lexer.grace
+++ b/lexer.grace
@@ -585,6 +585,11 @@ def LexerClass = object {
                         // lexical mode - process the old one now.
                         modechange(tokens, mode, accum)
                         if ((newmode == "}") && (interpdepth > 0)) then {
+                            if (prev == "\{") then {
+                                lineStr := lineStr ++ c
+                                lines.push(lineStr)
+                                util.syntax_error("Empty expression in interpolated block.")
+                            }
                             modechange(tokens, ")", ")")
                             modechange(tokens, "o", "++")
                             newmode := "\""

--- a/parser.grace
+++ b/parser.grace
@@ -814,7 +814,7 @@ method expressionrest {
                 // be allowed in term above?
                 next
                 if (accept("rparen")) then {
-                    util.syntax_error("Empty () in expression (maybe empty interpolated \{\} block).")
+                    util.syntax_error("Empty () in expression.")
                 }
                 expression
                 expect("rparen")


### PR DESCRIPTION
8a82e7c Removes invalid syntax for object inheritance `object extends Something.new`. This also removes several errors related to this syntax.
dfb3dff This catched empty interpolated blocks e.g. `"{}"` in the lexer so that they are not caught in the parser as empty expressions `()`, making it easier to understand where the problem is.
