### PR TITLE
Lexer error message fixes.

### DIFF
--- a/lexer.grace
+++ b/lexer.grace
@@ -281,31 +281,30 @@ def LexerClass = object {
                         tokens.push(tok)
                         done := true
                     } elseif (mode == "m") then {
-                        tok := makeNumToken(accum)
-                        if (tokens.size > 1) then {
-                            if (tokens.last.kind == "dot") then {
-                                tokens.pop
-                                if (tokens.last.kind == "num") then {
-                                    if (tokens.last.base == 10) then {
-                                        tok := tokens.pop
-                                        var decimal := makeNumToken(accum)
-                                        if(decimal.base == 10) then {
-                                            tok := NumToken.new(tok.value ++ "." ++ accum, 10)
-                                        } else {
-                                            lines.push(lineStr)
-                                            util.syntax_error("Fractional part of number must be in base 10.")
-                                        }
+                        if ((tokens.size > 1).andAlso {tokens.last.kind == "dot"}) then {
+                            tokens.pop
+                            if (tokens.last.kind == "num") then {
+                                if (tokens.last.base == 10) then {
+                                    tok := tokens.pop
+                                    var decimal := makeNumToken(accum)
+                                    if(decimal.base == 10) then {
+                                        tok := NumToken.new(tok.value ++ "." ++ accum, 10)
                                     } else {
                                         lines.push(lineStr)
-                                        util.syntax_error("Numbers in base {tokens.last.base} " ++
-                                            "can only be integers.")
+                                        util.syntax_error("Fractional part of number must be in base 10.")
                                     }
                                 } else {
                                     lines.push(lineStr)
-                                    util.syntax_error("Found '.{accum}'" ++
-                                        ", expected term.")
+                                    util.syntax_error("Numbers in base {tokens.last.base} " ++
+                                        "can only be integers.")
                                 }
+                            } else {
+                                lines.push(lineStr)
+                                util.syntax_error("Found '.{accum}'" ++
+                                    ", expected term.")
                             }
+                        } else {
+                            tok := makeNumToken(accum)
                         }
                         tokens.push(tok)
                         done := true


### PR DESCRIPTION
bad9516 Lines were showing up as "undefined" for error messages related to numbers. This is because the line was never added to the list of lines. In order to do this I had to increase the scope of `lines` and `lineStr` (and the c lines too) so that the line could be added from within `modechange`, `makeNumToken`, and `fromBase`.
3911992 For numbers such as 0x1bc.1f, the error message given was "No such digit in base 10: 'f'." whereas the correct message should have been "Numbers in base 16 can only be integers." This has now been corrected.
