### PR TITLE
Make if statements more consistent with other multi-part methods

### DIFF
--- a/parser.grace
+++ b/parser.grace
@@ -409,7 +409,11 @@ method doif {
     if (accept("identifier") && (sym.value == "if")) then {
         def btok = sym
         next
+        expect "lparen"
+        next
         expectConsume {expression}
+        expect "rparen"
+        next
         var cond := values.pop
         var body := []
 
@@ -450,7 +454,11 @@ method doif {
                 // "elseifs", turning them into ifs inside the else.
                 statementToken := sym
                 next
+                expect "lparen"
+                next
                 expectConsume {expression}
+                expect "rparen"
+                next
                 econd := values.pop
                 if ((accept("identifier") &&
                     (sym.value == "then")).not) then {


### PR DESCRIPTION
d2dd20a This requires parentheses around the arguments to `if` and `elseif`.

The next step to making if statements more consistent would be to allow code like this:

```
var trueblock := { print "true" }
var falseblock := { print "false" }

if (true) then (thenblock) else (falseblock)
```

But that seems more difficult due to the fact that `ast.ifNode` doesn't store blocks for the `then` and `else` blocks, it stores a list of statements.
