### PR TITLE
Overriding print

### DIFF
--- a/genc.grace
+++ b/genc.grace
@@ -1679,7 +1679,7 @@ method compilenode(o) {
         compilefor(o)
     }
     if ((o.kind == "call")) then {
-        if (o.value.value == "print") then {
+        if ((o.value.value == "print") && (o.value.in.value == "prelude")) then {
             var args := []
             for (o.with.first.args) do { prm ->
                 var r := compilenode(prm)

--- a/genjs.grace
+++ b/genjs.grace
@@ -1138,7 +1138,7 @@ method compilenode(o) {
         compilefor(o)
     }
     if ((o.kind == "call")) then {
-        if (o.value.value == "print") then {
+        if ((o.value.value == "print") && (o.value.in.value == "prelude")) then {
             var args := []
             for (o.with) do { part ->
                 for (part.args) do { prm ->

--- a/interactive.grace
+++ b/interactive.grace
@@ -354,7 +354,9 @@ class evalVisitor.new {
         def name = node.value.value
         def in = node.value.in
 
-        if (name == "print") then {
+        if ((name == "print") &&
+           (in.kind == "identifier") &&
+           (in.value == "prelude")) then {
             // print()
             var parts := []
             for (node.with) do { part ->


### PR DESCRIPTION
Currently the compiler turns any method call with the name "print" into a call to `gracelib_print`. This means that code that defines other methods called print, such as the following will not working properly.

```
import "io" as io

class Cat.new(name') {
    def name = name'
    method print {
        io.output.write("A cat named {name}.\n")
    }
}

Cat.new("Gregory").print
```

The fix in 956a768 fixes this by only using `gracelib_print` if the object that the method is being called on is `prelude` which it is unless `print` has been overridden. Furthermore, to use print within an overridden print method, you don't need to use `io.output.write`, you can use `prelude.print`.
