### PR TITLE
Require braces after 'then' in if statement.

### DIFF
--- a/parser.grace
+++ b/parser.grace
@@ -431,20 +431,19 @@ method doif {
         var minInd := statementIndent + 1
         if (accept("identifier") && (sym.value == "then")) then {
             next
-            if (accept("lbrace")) then {
-                next
-                if (sym.line == lastToken.line) then {
-                    minIndentLevel := sym.linePos - 1
-                } else {
-                    minIndentLevel := minInd
-                }
-                while {(accept("rbrace")).not} do {
-                    expectConsume {statement}
-                    v := values.pop
-                    body.push(v)
-                }
-                next
+            expect "lbrace"
+            next
+            if (sym.line == lastToken.line) then {
+                minIndentLevel := sym.linePos - 1
+            } else {
+                minIndentLevel := minInd
             }
+            while {(accept("rbrace")).not} do {
+                expectConsume {statement}
+                v := values.pop
+                body.push(v)
+            }
+            next
             var econd
             var eif
             var newelse


### PR DESCRIPTION
Currently if statements do not require a block after the 'then' keyword, allowing invalid code such as `if(true) then else {}`. This has been fixed, and also makes it consistent with the 'elseif' part of the statement.
