### PR TITLE
Fix some bugs in object parsing.

### DIFF
--- a/parser.grace
+++ b/parser.grace
@@ -1298,7 +1298,9 @@ method doobject {
             methoddec
             inheritsdec
             statement
-            if ((values.size == sz) && (lastToken.kind != "semicolon")) then {
+            if (sym.kind == "eof") then {
+                expect("rbrace")
+            } elseif ((values.size == sz) && (lastToken.kind != "semicolon")) then {
                 util.setPosition(sym.line, sym.linePos)
                 util.syntax_error("Unexpected symbol in "
                     ++ "object declaration. Expected 'var', 'def', 'method', "


### PR DESCRIPTION
0795bfa `statement` consumes semicolons but doesn't add anything to `values` so the error gets thrown when it shouldn't.
29bde7f The same error gets thrown when eof is encountered inside an object, when instead it should require a closing brace.
