### PR TITLE
Fix runtime exception/segfault in method calls

### DIFF
--- a/parser.grace
+++ b/parser.grace
@@ -887,6 +887,8 @@ method dotrest {
                 ) then {
                 callrest
             }
+        } else {
+            util.syntax_error("Expected identifier after '.'.")
         }
     }
 }


### PR DESCRIPTION
Currently if you have an identifier followed by a `.`, you aren't required to have anything else following the `.`.
This is the cause of several runtime exceptions and segmentation faults I have had recently.

Is this consistent with the Grace syntax? Is it possible to have an identifier followed by a `.` which is not followed by another identifier?
