### PR TITLE
Add object scope to variable scope in variable declaration

### DIFF
--- a/identifierresolution.grace
+++ b/identifierresolution.grace
@@ -647,6 +647,20 @@ method resolveIdentifiers(topNode) {
                 }
             }
         }
+        if ((node.kind == "vardec").andAlso({node.value != false})) then {
+            if (node.value.kind == "object") then {
+                scope.elementScopes.put(node.name.value, node.value.data)
+            } else {
+                def sc = findDeepScope(node.value)
+                scope.elementScopes.put(node.name.value, sc)
+            }
+            if (ast.findAnnotation(node, "parent")) then {
+                def sc = findDeepScope(node.value)
+                for (sc.elements) do {m->
+                    scope.add(m)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This was present for constant declaration, but not variable declaration. It would probably be nice to update `elementScopes` after binds also.
