### PR TITLE
Require method call continuations to be indented

### DIFF
--- a/parser.grace
+++ b/parser.grace
@@ -873,7 +873,7 @@ method expressionrest {
 // a following identifier, and will pass along to further lookups or
 // method calls on the result.
 method dotrest {
-    if (accept("dot")) then {
+    if (acceptSameLine("dot")) then {
         var lookuptarget := values.pop
         next
         if (accept("identifier")) then {


### PR DESCRIPTION
Currently the following code compiles and runs:

```
print(7
.asString)
```

Where it should be invalid as the second line is not indented, so is not a continuation.
