### PR TITLE
Add indentation to generated JavaScript

### DIFF
--- a/genjs.grace
+++ b/genjs.grace
@@ -8,6 +8,7 @@ import "xmodule" as xmodule
 import "mirrors" as mirrors
 
 var tmp
+var indent := ""
 var verbosity := 30
 var pad1 := 1
 var auto_count := 0
@@ -30,8 +31,20 @@ def staticmodules = mgcollections.set.new
 def topLevelTypes = mgcollections.map.new
 var dialectHasAtModuleEnd := false
 
+method increaseindent() {
+    indent := indent ++ "  "
+}
+
+method decreaseindent() {
+    if(indent.size <= 2) then {
+        indent := ""
+    } else {
+        indent := indent.substringFrom(1)to(indent.size - 2)
+    }
+}
+
 method out(s) {
-    output.push(s)
+    output.push(indent ++ s)
 }
 method outprint(s) {
     util.outprint(s)
@@ -89,10 +102,12 @@ method compilearray(o) {
         r := compilenode(a)
         vals.push(r)
     }
-    out("  var array" ++ myc ++ " = new GraceList([")
+    out("var array" ++ myc ++ " = new GraceList([")
+    increaseindent
     for (vals) do {v->
         out(v ++ ",")
     }
+    decreaseindent
     out("]);\n")
     o.register := "array" ++ myc
 }
@@ -107,11 +122,11 @@ method compileobjouter(selfr, outerRef) {
     auto_count := auto_count + 1
     var nm := escapestring("outer")
     var nmi := escapeident("outer")
-    out("  " ++ selfr ++ ".outer = " ++ outerRef ++ ";")
-    out("    var reader_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function() \{")
-    out("    return this.outer;")
-    out("  \}")
-    out("  " ++ selfr ++ ".methods[\"" ++ nm ++ "\"] = reader_" ++ modname ++
+    out(selfr ++ ".outer = " ++ outerRef ++ ";")
+    out("var reader_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function() \{")
+    out("  return this.outer;")
+    out("\}")
+    out(selfr ++ ".methods[\"" ++ nm ++ "\"] = reader_" ++ modname ++
         "_" ++ nmi ++ myc ++ ";")
 }
 method compileobjtype(o, selfr, pos) {
@@ -122,19 +137,19 @@ method compileobjtype(o, selfr, pos) {
     var nmi := escapeident(o.value)
     o.anonymous := true
     val := compilenode(o)
-    out("  " ++ selfr ++ ".data[\"" ++ nm ++ "\"] = " ++ val ++ ";")
-    out("    var reader_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function() \{")
-    out("    return this.data[\"" ++ nm ++ "\"];")
-    out("  \}")
-    out("  reader_{modname}_{nmi}{myc}.def = true;")
+    out(selfr ++ ".data[\"" ++ nm ++ "\"] = " ++ val ++ ";")
+    out("var reader_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function() \{")
+    out("  return this.data[\"" ++ nm ++ "\"];")
+    out("\}")
+    out("reader_{modname}_{nmi}{myc}.def = true;")
     var isReadable := false
     for (o.annotations) do {ann->
         if ((ann.kind == "identifier").andAlso
             {ann.value == "confidential"}) then {
-            out("  reader_{modname}_{nmi}{myc}.confidential = true;")
+            out("reader_{modname}_{nmi}{myc}.confidential = true;")
         }
     }
-    out("  " ++ selfr ++ ".methods[\"" ++ nm ++ "\"] = reader_" ++ modname ++
+    out(selfr ++ ".methods[\"" ++ nm ++ "\"] = reader_" ++ modname ++
         "_" ++ nmi ++ myc ++ ";")
 }
 method compileobjdefdec(o, selfr, pos) {
@@ -151,11 +166,11 @@ method compileobjdefdec(o, selfr, pos) {
     auto_count := auto_count + 1
     var nm := escapestring(o.name.value)
     var nmi := escapeident(o.name.value)
-    out("  " ++ selfr ++ ".data[\"" ++ nm ++ "\"] = " ++ val ++ ";")
-    out("    var reader_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function() \{")
-    out("    return this.data[\"" ++ nm ++ "\"];")
-    out("  \}")
-    out("  reader_{modname}_{nmi}{myc}.def = true;")
+    out(selfr ++ ".data[\"" ++ nm ++ "\"] = " ++ val ++ ";")
+    out("var reader_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function() \{")
+    out("  return this.data[\"" ++ nm ++ "\"];")
+    out("\}")
+    out("reader_{modname}_{nmi}{myc}.def = true;")
     var isReadable := false
     for (o.annotations) do {ann->
         if ((ann.kind == "identifier").andAlso
@@ -168,21 +183,21 @@ method compileobjdefdec(o, selfr, pos) {
         }
     }
     if (!isReadable) then {
-        out("  reader_{modname}_{nmi}{myc}.confidential = true;")
+        out("reader_{modname}_{nmi}{myc}.confidential = true;")
     }
-    out("  " ++ selfr ++ ".methods[\"" ++ nm ++ "\"] = reader_" ++ modname ++
+    out(selfr ++ ".methods[\"" ++ nm ++ "\"] = reader_" ++ modname ++
         "_" ++ nmi ++ myc ++ ";")
     if (ast.findAnnotation(o, "parent")) then {
-        out("  {selfr}.superobj = {val};")
+        out("{selfr}.superobj = {val};")
     }
     if (o.dtype != false) then {
         linenum := o.line
-        out "  lineNumber = {linenum};"
-        out "  if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
-        out "    [1], {val})))"
-        out "      throw new GraceExceptionPacket(TypeErrorObject,"
-        out "            new GraceString(\"expected \""
-        out "            + \"initial value of def '{o.name.value}' to be of type {o.dtype.value}\"))";
+        out "lineNumber = {linenum};"
+        out "if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
+        out "  [1], {val})))"
+        out "    throw new GraceExceptionPacket(TypeErrorObject,"
+        out "          new GraceString(\"expected \""
+        out "          + \"initial value of def '{o.name.value}' to be of type {o.dtype.value}\"))";
     }
 }
 method compileobjvardec(o, selfr, pos) {
@@ -194,17 +209,17 @@ method compileobjvardec(o, selfr, pos) {
     auto_count := auto_count + 1
     var nm := escapestring(o.name.value)
     var nmi := escapeident(o.name.value)
-    out("  " ++ selfr ++ ".data[\"" ++ nm ++ "\"] = " ++ val ++ ";")
-    out("    var reader_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function() \{")
-    out("    return this.data[\"" ++ nm ++ "\"];")
-    out("  \}")
-    out("  " ++ selfr ++ ".methods[\"" ++ nm ++ "\"] = reader_" ++ modname ++
+    out(selfr ++ ".data[\"" ++ nm ++ "\"] = " ++ val ++ ";")
+    out("var reader_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function() \{")
+    out("  return this.data[\"" ++ nm ++ "\"];")
+    out("\}")
+    out(selfr ++ ".methods[\"" ++ nm ++ "\"] = reader_" ++ modname ++
         "_" ++ nmi ++ myc ++ ";")
-    out("  " ++ selfr ++ ".data[\"" ++ nm ++ "\"] = " ++ val ++ ";")
-    out("  var writer_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function(argcv, o) \{")
-    out("    this.data[\"" ++ nm ++ "\"] = o;")
-    out("  \}")
-    out("  " ++ selfr ++ ".methods[\"" ++ nm ++ ":=\"] = writer_" ++ modname ++
+    out(selfr ++ ".data[\"" ++ nm ++ "\"] = " ++ val ++ ";")
+    out("var writer_" ++ modname ++ "_" ++ nmi ++ myc ++ " = function(argcv, o) \{")
+    out("  this.data[\"" ++ nm ++ "\"] = o;")
+    out("\}")
+    out(selfr ++ ".methods[\"" ++ nm ++ ":=\"] = writer_" ++ modname ++
         "_" ++ nmi ++ myc ++ ";")
     var isReadable := false
     var isWritable := false
@@ -224,22 +239,22 @@ method compileobjvardec(o, selfr, pos) {
         }
     }
     if (!isReadable) then {
-        out("  reader_{modname}_{nmi}{myc}.confidential = true;")
+        out("reader_{modname}_{nmi}{myc}.confidential = true;")
     }
     if (!isWritable) then {
-        out("  writer_{modname}_{nmi}{myc}.confidential = true;")
+        out("writer_{modname}_{nmi}{myc}.confidential = true;")
     }
     if (o.dtype != false) then {
         if (val == "undefined") then {
             return true
         }
         linenum := o.line
-        out "  lineNumber = {linenum};"
-        out "  if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
-        out "    [1], {val})))"
-        out "      throw new GraceExceptionPacket(TypeErrorObject,"
-        out "            new GraceString(\"expected \""
-        out "            + \"initial value of var '{o.name.value}' to be of type {o.dtype.value}\"))";
+        out "lineNumber = {linenum};"
+        out "if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
+        out "  [1], {val})))"
+        out "    throw new GraceExceptionPacket(TypeErrorObject,"
+        out "          new GraceString(\"expected \""
+        out "          + \"initial value of var '{o.name.value}' to be of type {o.dtype.value}\"))";
     }
 }
 method compileclass(o) {
@@ -276,17 +291,18 @@ method compileobject(o, outerRef, inheritingObject) {
             superobj := e.value
         }
     }
-    out("  var " ++ selfr ++ " = Grace_allocObject();")
+    out("var " ++ selfr ++ " = Grace_allocObject();")
     if (inheritingObject) then {
-        out "  var inho{myc} = inheritingObject;"
-        out "  while (inho{myc}.superobj) inho{myc} = inho{myc}.superobj;"
-        out "  inho{myc}.superobj = {selfr};"
-        out "  {selfr}.data = inheritingObject.data;"
+        out "var inho{myc} = inheritingObject;"
+        out "while (inho{myc}.superobj) inho{myc} = inho{myc}.superobj;"
+        out "inho{myc}.superobj = {selfr};"
+        out "{selfr}.data = inheritingObject.data;"
     }
     compileobjouter(selfr, outerRef)
     out("function obj_init_{myc}() \{")
-    out("  var origSuperDepth = superDepth;")
-    out("  superDepth = {selfr};")
+    increaseindent
+    out("var origSuperDepth = superDepth;")
+    out("superDepth = {selfr};")
     var pos := 0
     for (o.value) do { e ->
         if (e.kind == "method") then {
@@ -294,7 +310,7 @@ method compileobject(o, outerRef, inheritingObject) {
         }
     }
     for (o.value) do { e ->
-        out "  sourceObject = {selfr};"
+        out("sourceObject = {selfr};")
         if (e.kind == "method") then {
         } elseif (e.kind == "vardec") then {
             compileobjvardec(e, selfr, pos)
@@ -310,13 +326,14 @@ method compileobject(o, outerRef, inheritingObject) {
             compileobject(e, selfr, false)
         } elseif (e.kind == "inherits") then {
             def so = compilenode(e.value)
-            out "  {selfr}.superobj = {so};"
-            out "  {selfr}._value = {so}._value;"
+            out("{selfr}.superobj = {so};")
+            out("{selfr}._value = {so}._value;")
         } else {
             compilenode(e)
         }
     }
-    out("  superDepth = origSuperDepth;")
+    out("superDepth = origSuperDepth;")
+    decreaseindent
     out("\}")
     if (inheritingObject) then {
         out("obj_init_{myc}.apply(inheritingObject, []);")
@@ -331,25 +348,26 @@ method compileblock(o) {
     inBlock := true
     var myc := auto_count
     auto_count := auto_count + 1
-    out("  var block" ++ myc ++ " = Grace_allocObject();")
-    out("  block" ++ myc ++ ".methods[\"apply\"] = function() \{")
-    out("    var args = Array.prototype.slice.call(arguments, 1);")
-    out("    return this.real.apply(this.receiver, args);")
-    out("  \}")
-    out("  block" ++ myc ++ ".methods[\"applyIndirectly\"] = function(argcv, a) \{")
-    out("    return this.real.apply(this.receiver, a._value);")
-    out("  \}")
-    out("  block" ++ myc ++ ".methods[\"outer\"] = function() \{")
-    out("    return callmethod(this.receiver, 'outer', [0]);")
-    out("  \}")
+    out("var block" ++ myc ++ " = Grace_allocObject();")
+    out("block" ++ myc ++ ".methods[\"apply\"] = function() \{")
+    out("  var args = Array.prototype.slice.call(arguments, 1);")
+    out("  return this.real.apply(this.receiver, args);")
+    out("\}")
+    out("block" ++ myc ++ ".methods[\"applyIndirectly\"] = function(argcv, a) \{")
+    out("  return this.real.apply(this.receiver, a._value);")
+    out("\}")
+    out("block" ++ myc ++ ".methods[\"outer\"] = function() \{")
+    out("  return callmethod(this.receiver, 'outer', [0]);")
+    out("\}")
     if (false != o.matchingPattern) then {
         def pat = compilenode(o.matchingPattern)
-        out("  block{myc}.pattern = {pat};")
+        out("block{myc}.pattern = {pat};")
     }
-    out("  block{myc}.methods[\"match\"] = GraceBlock_match;")
-    out("  block" ++ myc ++ ".receiver = this;")
-    out("  block{myc}.className = 'block<{modname}:{o.line}>';")
-    out("  block" ++ myc ++ ".real = function(")
+    out("block{myc}.methods[\"match\"] = GraceBlock_match;")
+    out("block" ++ myc ++ ".receiver = this;")
+    out("block{myc}.className = 'block<{modname}:{o.line}>';")
+    out("block" ++ myc ++ ".real = function(")
+    increaseindent
     var first := true
     for (o.params) do {p->
         if (first.not) then {
@@ -358,13 +376,16 @@ method compileblock(o) {
         first := false
         out(varf(p.value))
     }
+    decreaseindent
     out(") \{")
-    out("  sourceObject = this;")
+    increaseindent
+    out("sourceObject = this;")
     var ret := "undefined"
     for (o.body) do {l->
         ret := compilenode(l)
     }
-    out("  return " ++ ret ++ ";")
+    out("return " ++ ret ++ ";")
+    decreaseindent
     out("\};")
     o.register := "block" ++ myc
     inBlock := origInBlock
@@ -395,15 +416,15 @@ method compilefor(o) {
     var over := compilenode(o.value)
     var blk := o.body
     var blko := compilenode(blk)
-    out("  var it" ++ myc ++ " = " ++ over ++ ".methods[\"iterator\"].call("
+    out("var it" ++ myc ++ " = " ++ over ++ ".methods[\"iterator\"].call("
         ++ over ++ ", [0]);")
     out("while (Grace_isTrue(it" ++ myc ++ ".methods[\"havemore\"].call("
         ++ "it" ++ myc ++ ", [0]))) \{")
-    out("    var fv" ++ myc ++ " = it" ++ myc ++ ".methods[\"next\"].call("
+    out("  var fv" ++ myc ++ " = it" ++ myc ++ ".methods[\"next\"].call("
         ++ "it" ++ myc ++ ", [0]);")
-    out("    " ++ blko ++ ".methods[\"apply\"].call("
+    out("  " ++ blko ++ ".methods[\"apply\"].call("
         ++ blko ++ ", [1], fv" ++ myc ++ ");")
-    out("  \}")
+    out("\}")
     o.register := over
 }
 method compilemethod(o, selfobj) {
@@ -435,22 +456,23 @@ method compilemethod(o, selfobj) {
         }
     }
     out("var func" ++ myc ++ " = function(argcv) \{")
-    out("  var curarg = 1;")
+    increaseindent
+    out("var curarg = 1;")
     for (o.signature.indices) do { partnr ->
         var part := o.signature[partnr]
         for (part.params) do { p ->
-            out("  var {varf(p.value)} = arguments[curarg];")
-            out("  curarg++;")
+            out("var {varf(p.value)} = arguments[curarg];")
+            out("curarg++;")
         }
         if (part.vararg != false) then {
-            out("  var {varf(part.vararg.value)} = new GraceList("
+            out("var {varf(part.vararg.value)} = new GraceList("
                 ++ "Array.prototype.slice.call(arguments, curarg, "
                 ++ "curarg + argcv[{partnr - 1}] - {part.params.size}));")
-            out("  curarg += argcv[{partnr - 1}] - {part.params.size};")
+            out("curarg += argcv[{partnr - 1}] - {part.params.size};")
         } else {
             if (!o.selfclosure) then {
-                out "  if (argcv[{partnr - 1}] !=  func{myc}.paramCounts[{partnr - 1}])"
-                out("      callmethod(RuntimeErrorObject, \"raise\", [1], new "
+                out "if (argcv[{partnr - 1}] !=  func{myc}.paramCounts[{partnr - 1}])"
+                out("  callmethod(RuntimeErrorObject, \"raise\", [1], new "
                     ++ "GraceString(\"wrong number of arguments for part "
                     ++ "{partnr} ({part.name})\"));")
             }
@@ -458,19 +480,19 @@ method compilemethod(o, selfobj) {
     }
     if (o.generics.size > 0) then {
         out("// Start generics")
-        out("  if (argcv.length == 1 + {o.signature.size}) \{")
-        out("    if (argcv[argcv.length-1] < {o.generics.size}) \{")
-        out("      callmethod(RuntimeErrorObject, \"raise\", [1], "
+        out("if (argcv.length == 1 + {o.signature.size}) \{")
+        out("  if (argcv[argcv.length-1] < {o.generics.size}) \{")
+        out("    callmethod(RuntimeErrorObject, \"raise\", [1], "
             ++ "new GraceString(\"insufficient generic parameters\"));")
-        out("    \}")
+        out("  \}")
         for (o.generics) do {g->
             out("  var {varf(g.value)} = arguments[curarg++];")
         }
-        out("  \} else \{")
+        out("\} else \{")
         for (o.generics) do {g->
-            out("    {varf(g.value)} = var_Dynamic;")
+            out("  {varf(g.value)} = var_Dynamic;")
         }
-        out("  \}")
+        out("\}")
         out("// End generics")
         out "var curarg2 = 1;"
         for (o.signature.indices) do { partnr ->
@@ -480,42 +502,45 @@ method compilemethod(o, selfobj) {
                     for (o.generics) do {g->
                         if (p.dtype.value == g.value) then {
                             linenum := o.line
-                            out "  lineNumber = {linenum};"
-                            out "  if (!Grace_isTrue(callmethod({compilenode(p.dtype)}, \"match\","
-                            out "    [1], arguments[curarg2])))"
-                            out "      throw new GraceExceptionPacket(TypeErrorObject,"
-                            out "            new GraceString(\"expected \""
-                            out "             + \"parameter '{p.value}' \""
-                            out "             + \"to be of type {p.dtype.value}\"));";
+                            out "lineNumber = {linenum};"
+                            out "if (!Grace_isTrue(callmethod({compilenode(p.dtype)}, \"match\","
+                            out "  [1], arguments[curarg2])))"
+                            out "    throw new GraceExceptionPacket(TypeErrorObject,"
+                            out "          new GraceString(\"expected \""
+                            out "           + \"parameter '{p.value}' \""
+                            out "           + \"to be of type {p.dtype.value}\"));";
                         }
                     }
                 }
-                out("  curarg2++;")
+                out("curarg2++;")
             }
             if (part.vararg != false) then {
-                out("  var {varf(part.vararg.value)} = new GraceList("
+                out("var {varf(part.vararg.value)} = new GraceList("
                     ++ "Array.prototype.slice.call(arguments, curarg2, "
                     ++ "curarg2 + argcv[{partnr - 1}] - {part.params.size}));")
-                out("  curarg2 += argcv[{partnr - 1}] - {part.params.size};")
+                out("curarg2 += argcv[{partnr - 1}] - {part.params.size};")
             }
         }
         out "// End checking generics"
     }
-    out("  var returnTarget = invocationCount;")
-    out("  invocationCount++;")
-    out("  try \{")
+    out("var returnTarget = invocationCount;")
+    out("invocationCount++;")
+    out("try \{")
+    increaseindent
     var ret := "undefined"
     for (o.body) do { l ->
         ret := compilenode(l)
     }
-    out("  return " ++ ret)
-    out("  \} catch(e) \{")
-    out("    if ((e.exctype == 'return') && (e.target == returnTarget)) \{")
-    out("      return e.returnvalue;")
-    out("    \} else \{")
-    out("      throw e;")
-    out("    \}")
+    out("return " ++ ret)
+    decreaseindent
+    out("\} catch(e) \{")
+    out("  if ((e.exctype == 'return') && (e.target == returnTarget)) \{")
+    out("    return e.returnvalue;")
+    out("  \} else \{")
+    out("    throw e;")
     out("  \}")
+    out("\}")
+    decreaseindent
     out("\}")
     usedvars := oldusedvars
     declaredvars := olddeclaredvars
@@ -528,21 +553,23 @@ method compilemethod(o, selfobj) {
             out("func{myc}.confidential = true;")
         }
     }
-    out "  func{myc}.paramCounts = ["
+    out "func{myc}.paramCounts = ["
+    increaseindent
     for (paramCounts) do {p->
-        out("    {p},")
+        out("{p},")
     }
+    decreaseindent
     out "];"
-    out "  func{myc}.variableArities = ["
+    out "func{myc}.variableArities = ["
     for (variableArities) do {p->
         if (p) then {
-            out "    true,"
+            out "  true,"
         } else {
-            out "    false,"
+            out "  false,"
         }
     }
     out "];"
-    out("  {selfobj}.methods[\"{name}\"] = func{myc};")
+    out("{selfobj}.methods[\"{name}\"] = func{myc};")
     if (o.properties.contains("fresh")) then {
         compilefreshmethod(o, selfobj)
     }
@@ -565,41 +592,43 @@ method compilefreshmethod(o, selfobj) {
         }
     }
     out("var func" ++ myc ++ " = function(argcv) \{")
-    out("  var curarg = 1;")
+    increaseindent
+    out("var curarg = 1;")
     for (o.signature.indices) do { partnr ->
         var part := o.signature[partnr]
         for (part.params) do { p ->
-            out("  var {varf(p.value)} = arguments[curarg];")
-            out("  curarg++;")
+            out("var {varf(p.value)} = arguments[curarg];")
+            out("curarg++;")
         }
         if (part.vararg != false) then {
-            out("  var {varf(part.vararg.value)} = new GraceList("
+            out("var {varf(part.vararg.value)} = new GraceList("
                 ++ "Array.prototype.slice.call(arguments, curarg, "
                 ++ "curarg + argcv[{partnr - 1}] - {part.params.size}));")
-            out("  curarg += argcv[{partnr - 1}] - {part.params.size};")
+            out("curarg += argcv[{partnr - 1}] - {part.params.size};")
         }
     }
-    out "  var inheritingObject = arguments[curarg++];"
+    out "var inheritingObject = arguments[curarg++];"
     if (o.generics.size > 0) then {
         out("// Start generics")
-        out("  if (argcv.length == 1 + {o.signature.size}) \{")
-        out("    if (argcv[argcv.length-1] < {o.generics.size}) \{")
-        out("      callmethod(RuntimeErrorObject, \"raise\", [1], "
+        out("if (argcv.length == 1 + {o.signature.size}) \{")
+        out("  if (argcv[argcv.length-1] < {o.generics.size}) \{")
+        out("    callmethod(RuntimeErrorObject, \"raise\", [1], "
             ++ "new GraceString(\"insufficient generic parameters\"));")
-        out("    \}")
+        out("  \}")
         for (o.generics) do {g->
             out("  var {varf(g.value)} = arguments[curarg++];")
         }
-        out("  \} else \{")
+        out("\} else \{")
         for (o.generics) do {g->
-            out("    {varf(g.value)} = var_Dynamic;")
+            out("  {varf(g.value)} = var_Dynamic;")
         }
-        out("  \}")
+        out("\}")
         out("// End generics")
     }
-    out("  var returnTarget = invocationCount;")
-    out("  invocationCount++;")
-    out("  try \{")
+    out("var returnTarget = invocationCount;")
+    out("invocationCount++;")
+    out("try \{")
+    increaseindent
     var tailObject := false
     if ((o.body.size > 0).andAlso {o.body.last.kind == "object"}) then {
         tailObject := o.body.pop
@@ -612,14 +641,16 @@ method compilefreshmethod(o, selfobj) {
         compileobject(tailObject, "this", true)
         ret := tailObject.register
     }
-    out("  return " ++ ret)
-    out("  \} catch(e) \{")
-    out("    if ((e.exctype == 'return') && (e.target == returnTarget)) \{")
-    out("      return e.returnvalue;")
-    out("    \} else \{")
-    out("      throw e;")
-    out("    \}")
+    out("return " ++ ret)
+    decreaseindent
+    out("\} catch(e) \{")
+    out("  if ((e.exctype == 'return') && (e.target == returnTarget)) \{")
+    out("    return e.returnvalue;")
+    out("  \} else \{")
+    out("    throw e;")
     out("  \}")
+    out("\}")
+    decreaseindent
     out("\}")
     if (haveTypedParams) then {
         compilemethodtypes("func{myc}", o)
@@ -630,7 +661,7 @@ method compilefreshmethod(o, selfobj) {
             out("func{myc}.confidential = true;")
         }
     }
-    out("  " ++ selfobj ++ ".methods[\"" ++ name ++ "()object\"] = func" ++ myc ++ ";")
+    out(selfobj ++ ".methods[\"" ++ name ++ "()object\"] = func" ++ myc ++ ";")
 }
 method compilemethodtypes(func, o) {
     out("{func}.paramTypes = [];")
@@ -663,33 +694,39 @@ method compilewhile(o) {
     var myc := auto_count
     auto_count := auto_count + 1
     var cond := compilenode(o.value)
-    out("  var wcond" ++ myc ++ " = Grace_isTrue(" ++ cond ++ ");")
-    out("  while (wcond" ++ myc ++ ") \{")
+    out("var wcond" ++ myc ++ " = Grace_isTrue(" ++ cond ++ ");")
+    out("while (wcond" ++ myc ++ ") \{")
+    increaseindent
     var tret := "null"
     for (o.body) do { l->
         tret := compilenode(l)
     }
     cond := compilenode(o.value)
-    out("  wcond" ++ myc ++ " = Grace_isTrue(" ++ cond ++ ");")
-    out("  \}")
+    out("wcond" ++ myc ++ " = Grace_isTrue(" ++ cond ++ ");")
+    decreaseindent
+    out("\}")
     o.register := cond // "%while" ++ myc
 }
 method compileif(o) {
     var myc := auto_count
     auto_count := auto_count + 1
-    out("  if (Grace_isTrue(" ++ compilenode(o.value) ++ ")) \{")
+    out("if (Grace_isTrue(" ++ compilenode(o.value) ++ ")) \{")
+    increaseindent
     var tret := "undefined"
     var fret := "undefined"
     for (o.thenblock) do { l->
         tret := compilenode(l)
     }
-    out("  var if" ++ myc ++ " = " ++ tret ++ ";")
+    out("var if" ++ myc ++ " = " ++ tret ++ ";")
+    decreaseindent
     if (o.elseblock.size > 0) then {
-        out("  \} else \{")
+        out("\} else \{")
+        increaseindent
         for (o.elseblock) do { l->
             fret := compilenode(l)
         }
-        out("  var if" ++ myc ++ " = " ++ fret ++ ";")
+        out("var if" ++ myc ++ " = " ++ fret ++ ";")
+        decreaseindent
     }
     out("\}")
     o.register := "if" ++ myc
@@ -702,8 +739,8 @@ method compileidentifier(o) {
         o.register := "ellipsis"
     } else {
         if (modules.contains(name)) then {
-            out("  // WARNING: module support not implemented in JS backend")
-            out("  \"var_val_" ++ name ++ auto_count
+            out("// WARNING: module support not implemented in JS backend")
+            out("\"var_val_" ++ name ++ auto_count
                 ++ "\" = load %object** @.module." ++ name)
         } else {
             usedvars.push(name)
@@ -721,7 +758,7 @@ method compilebind(o) {
         val := compilenode(val)
         var nm := dest.value
         usedvars.push(nm)
-        out("  " ++ varf(nm) ++ " = " ++ val ++ ";")
+        out(varf(nm) ++ " = " ++ val ++ ";")
         o.register := val
     } elseif (dest.kind == "member") then {
         if (dest.value.substringFrom(dest.value.size - 1)to(dest.value.size)
@@ -749,22 +786,22 @@ method compiledefdec(o) {
     nm := snm
     declaredvars.push(nm)
     var val := compilenode(o.value)
-    out("  var " ++ varf(nm) ++ " = " ++ val ++ ";")
+    out("var " ++ varf(nm) ++ " = " ++ val ++ ";")
     if (compilationDepth == 1) then {
         compilenode(ast.methodNode.new(o.name, [ast.signaturePart.new(o.name.value)],
             [o.name], false))
         if (ast.findAnnotation(o, "parent")) then {
-            out("  this.superobj = {val};")
+            out("this.superobj = {val};")
         }
     }
     if (o.dtype != false) then {
         linenum := o.line
-        out "  lineNumber = {linenum};"
-        out "  if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
-        out "    [1], {varf(nm)})))"
-        out "      throw new GraceExceptionPacket(TypeErrorObject,"
-        out "            new GraceString(\"expected \""
-        out "            + \"initial value of def '{snm}' to be of type {o.dtype.value}\"))";
+        out "lineNumber = {linenum};"
+        out "if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
+        out "  [1], {varf(nm)})))"
+        out "    throw new GraceExceptionPacket(TypeErrorObject,"
+        out "          new GraceString(\"expected \""
+        out "          + \"initial value of def '{snm}' to be of type {o.dtype.value}\"))";
     }
     o.register := val
 }
@@ -774,9 +811,9 @@ method compilevardec(o) {
     var val := o.value
     if (false != val) then {
         val := compilenode(val)
-        out("  var " ++ varf(nm) ++ " = " ++ val ++ ";")
+        out("var " ++ varf(nm) ++ " = " ++ val ++ ";")
     } else {
-        out("  var " ++ varf(nm) ++ ";")
+        out("var " ++ varf(nm) ++ ";")
         val := "false"
     }
     if (compilationDepth == 1) then {
@@ -791,12 +828,12 @@ method compilevardec(o) {
     if (o.dtype != false) then {
         if (val != "false") then {
             linenum := o.line
-            out "  lineNumber = {linenum};"
-            out "  if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
-            out "    [1], {varf(nm)})))"
-            out "      throw new GraceExceptionPacket(TypeErrorObject,"
-            out "            new GraceString(\"expected \""
-            out "            + \"initial value of var '{o.name.value}' to be of type {o.dtype.value}\"))";
+            out "lineNumber = {linenum};"
+            out "if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
+            out "  [1], {varf(nm)})))"
+            out "    throw new GraceExceptionPacket(TypeErrorObject,"
+            out "          new GraceString(\"expected \""
+            out "          + \"initial value of var '{o.name.value}' to be of type {o.dtype.value}\"))";
         }
     }
     o.register := val
@@ -804,7 +841,7 @@ method compilevardec(o) {
 method compileindex(o) {
     var of := compilenode(o.value)
     var index := compilenode(o.index)
-    out("  var idxres" ++ auto_count ++ " = " ++ of ++ ".methods[\"[]\"]"
+    out("var idxres" ++ auto_count ++ " = " ++ of ++ ".methods[\"[]\"]"
         ++ ".call(" ++ of ++ ", [1], " ++ index ++ ");")
     o.register := "idxres" ++ auto_count
     auto_count := auto_count + 1
@@ -814,16 +851,16 @@ method compilecatchcase(o) {
     auto_count := auto_count + 1
     def cases = o.cases
     def mainblock = compilenode(o.value)
-    out("  var cases{myc} = [];")
+    out("var cases{myc} = [];")
     for (cases) do {c->
         def e = compilenode(c)
-        out("  cases{myc}.push({e});")
+        out("cases{myc}.push({e});")
     }
     var finally := "false"
     if (false != o.finally) then {
         finally := compilenode(o.finally)
     }
-    out("  var catchres{myc} = catchCase({mainblock},cases{myc},{finally});")
+    out("var catchres{myc} = catchCase({mainblock},cases{myc},{finally});")
     o.register := "catchres" ++ myc
 }
 method compilematchcase(o) {
@@ -831,16 +868,16 @@ method compilematchcase(o) {
     auto_count := auto_count + 1
     def cases = o.cases
     def matchee = compilenode(o.value)
-    out("  var cases{myc} = [];")
+    out("var cases{myc} = [];")
     for (cases) do {c->
         def e = compilenode(c)
-        out("  cases{myc}.push({e});")
+        out("cases{myc}.push({e});")
     }
     var elsecase := "false"
     if (false != o.elsecase) then {
         elsecase := compilenode(o.elsecase)
     }
-    out("  var matchres{myc} = matchCase({matchee},cases{myc},{elsecase});")
+    out("var matchres{myc} = matchCase({matchee},cases{myc},{elsecase});")
     o.register := "matchres" ++ myc
 }
 method compileop(o) {
@@ -860,7 +897,7 @@ method compileop(o) {
     if (o.value == "%") then {
         rnm := "modulus"
     }
-    out("  var " ++ rnm ++ auto_count ++ " = callmethod(" ++ left
+    out("var " ++ rnm ++ auto_count ++ " = callmethod(" ++ left
         ++ ", \"" ++ o.value ++ "\", [1], " ++ right ++ ");")
     o.register := rnm ++ auto_count
     auto_count := auto_count + 1
@@ -893,7 +930,7 @@ method compilecall(o) {
     }
     if ((o.value.kind == "member") && {(o.value.in.kind == "identifier")
         && (o.value.in.value == "super")}) then {
-        var call := "  var call" ++ auto_count ++ " = callmethodsuper(this"
+        var call := "var call" ++ auto_count ++ " = callmethodsuper(this"
             ++ ", \"" ++ escapestring(o.value.value) ++ "\", ["
         call := call ++ partl ++ "]"
         for (args) do { arg ->
@@ -905,7 +942,7 @@ method compilecall(o) {
         o.value.in.kind == "member"}.andAlso {
             o.value.in.value == "outer"}) then {
         def ot = compilenode(o.value.in)
-        var call := "  var call" ++ auto_count ++ " = callmethod({ot}"
+        var call := "var call" ++ auto_count ++ " = callmethod({ot}"
             ++ ", \"" ++ escapestring(o.value.value) ++ "\", ["
         call := call ++ partl ++ "]"
         for (args) do { arg ->
@@ -918,11 +955,11 @@ method compilecall(o) {
     } elseif ((o.value.kind == "member") && {(o.value.in.kind == "identifier")
         && (o.value.in.value == "self") && (o.value.value == "outer")}
         ) then {
-        out("  var call{auto_count} = callmethod(superDepth, "
+        out("var call{auto_count} = callmethod(superDepth, "
             ++ "\"outer\", [0]);")
     } elseif ((o.value.kind == "member") && {(o.value.in.kind == "identifier")
         && (o.value.in.value == "self")}) then {
-        var call := "  var call" ++ auto_count ++ " = callmethod(this"
+        var call := "var call" ++ auto_count ++ " = callmethod(this"
             ++ ", \"" ++ escapestring(o.value.value) ++ "\", ["
         call := call ++ partl ++ "]"
         for (args) do { arg ->
@@ -933,7 +970,7 @@ method compilecall(o) {
         out(call)
     } elseif ((o.value.kind == "member") && {(o.value.in.kind == "identifier")
         && (o.value.in.value == "prelude")}) then {
-        var call := "  var call" ++ auto_count ++ " = callmethod(Grace_prelude"
+        var call := "var call" ++ auto_count ++ " = callmethod(Grace_prelude"
             ++ ",\"" ++ escapestring(o.value.value) ++ "\", ["
         call := call ++ partl ++ "]"
         for (args) do { arg ->
@@ -943,7 +980,7 @@ method compilecall(o) {
         out(call)
     } elseif (o.value.kind == "member") then {
         obj := compilenode(o.value.in)
-        var call := "  var call" ++ auto_count ++ " = callmethod(" ++ obj
+        var call := "var call" ++ auto_count ++ " = callmethod(" ++ obj
             ++ ",\"" ++ escapestring(o.value.value) ++ "\", ["
         call := call ++ partl ++ "]"
         for (args) do { arg ->
@@ -953,7 +990,7 @@ method compilecall(o) {
         out(call)
     } else {
         obj := "this"
-        var call := "  var call" ++ auto_count ++ " = callmethod(this,"
+        var call := "var call" ++ auto_count ++ " = callmethod(this,"
             ++ "\"" ++ escapestring(o.value.value) ++ "\", ["
         call := call ++ partl ++ "]"
         for (args) do { arg ->
@@ -976,23 +1013,23 @@ method compileoctets(o) {
         escval := escval ++ c
         i := i + 1
     }
-    out("  %tmp" ++ auto_count ++ " = load %object** @.octlit"
+    out("%tmp" ++ auto_count ++ " = load %object** @.octlit"
         ++ auto_count)
-    out("  %cmp" ++ auto_count ++ " = icmp ne %object* %tmp"
+    out("%cmp" ++ auto_count ++ " = icmp ne %object* %tmp"
         ++ auto_count ++ ", null")
-    out("  br i1 %cmp" ++ auto_count ++ ", label %octlit"
+    out("br i1 %cmp" ++ auto_count ++ ", label %octlit"
         ++ auto_count ++ ".already, label %octlit"
         ++ auto_count ++ ".define")
     beginblock("octlit" ++ auto_count ++ ".already")
-    out("  %alreadyoctets" ++ auto_count ++ " = load %object** @.octlit"
+    out("%alreadyoctets" ++ auto_count ++ " = load %object** @.octlit"
         ++ auto_count)
-    out("  br label %octlit" ++ auto_count ++ ".end")
+    out("br label %octlit" ++ auto_count ++ ".end")
     beginblock("octlit" ++ auto_count ++ ".define")
-    out("  %oct" ++ auto_count ++ " = getelementptr [" ++ l ++ " x i8]* @.oct" ++ constants.size ++ ", i32 0, i32 0")
-    out("  %defoctets" ++ auto_count ++ " = call %object* "
+    out("%oct" ++ auto_count ++ " = getelementptr [" ++ l ++ " x i8]* @.oct" ++ constants.size ++ ", i32 0, i32 0")
+    out("%defoctets" ++ auto_count ++ " = call %object* "
         ++ "@alloc_Octets(i8* "
           ++ "%oct" ++ auto_count ++ ", i32 " ++ l ++ ")")
-    out("  store %object* %defoctets" ++ auto_count ++ ", %object** "
+    out("store %object* %defoctets" ++ auto_count ++ ", %object** "
         ++ "@.octlit" ++ auto_count)
     out("br label %octlit" ++ auto_count ++ ".end")
     beginblock("octlit" ++ auto_count ++ ".end")
@@ -1036,25 +1073,25 @@ method compileimport(o) {
     }
     var nm := escapestring(o.value)
     var fn := escapestring(o.path)
-    out("  if (typeof gracecode_{snm} == 'undefined')")
-    out "    throw new GraceExceptionPacket(RuntimeErrorObject, "
-    out "      new GraceString('could not find module {snm}'));"
-    out("  var " ++ varf(nm) ++ " = do_import(\"{fn}\", gracecode_{snm});")
+    out("if (typeof gracecode_{snm} == 'undefined')")
+    out "  throw new GraceExceptionPacket(RuntimeErrorObject, "
+    out "    new GraceString('could not find module {snm}'));"
+    out("var " ++ varf(nm) ++ " = do_import(\"{fn}\", gracecode_{snm});")
     if (o.dtype != false) then {
-        out "  if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
-        out "    [1], {varf(nm)})))"
-        out "      throw new GraceExceptionPacket(TypeErrorObject,"
-        out "            new GraceString(\"expected \""
-        out "            + \"module {snm} to be of type {o.dtype.value}\"))";
+        out "if (!Grace_isTrue(callmethod({compilenode(o.dtype)}, \"match\","
+        out "  [1], {varf(nm)})))"
+        out "    throw new GraceExceptionPacket(TypeErrorObject,"
+        out "          new GraceString(\"expected \""
+        out "          + \"module {snm} to be of type {o.dtype.value}\"))";
     }
     o.register := "undefined"
 }
 method compilereturn(o) {
     var reg := compilenode(o.value)
     if (inBlock) then {
-        out("  throw new ReturnException(" ++ reg ++ ", returnTarget);")
+        out("throw new ReturnException(" ++ reg ++ ", returnTarget);")
     } else {
-        out("  return " ++ reg)
+        out("return " ++ reg)
     }
     o.register := "undefined"
 }
@@ -1062,7 +1099,7 @@ method compilenode(o) {
     compilationDepth := compilationDepth + 1
     if (linenum != o.line) then {
         linenum := o.line
-        out("  lineNumber = " ++ linenum);
+        out("lineNumber = " ++ linenum);
     }
     if (o.kind == "num") then {
         o.register := "new GraceNum(" ++ o.value ++ ")"
@@ -1074,7 +1111,7 @@ method compilenode(o) {
         var os := ""
         // Escape characters that may not be legal in string literals
         os := escapestring(o.value)
-        out("  var string" ++ auto_count ++ " = new GraceString(\""
+        out("var string" ++ auto_count ++ " = new GraceString(\""
             ++ os ++ "\");")
         o.register := "string" ++ auto_count
         auto_count := auto_count + 1
@@ -1103,7 +1140,7 @@ method compilenode(o) {
         if (o.value == "true") then {
             val := 1
         }
-        out("  var bool" ++ auto_count ++ " = new GraceBoolean(" ++ o.value ++ ")")
+        out("var bool" ++ auto_count ++ " = new GraceBoolean(" ++ o.value ++ ")")
         o.register := "bool" ++ auto_count
         auto_count := auto_count + 1
     } elseif (o.kind == "identifier") then {
@@ -1164,9 +1201,9 @@ method compilenode(o) {
                 }
             }
             if(args.size == 0) then {
-                out("  var call" ++ auto_count ++ " = Grace_print(new GraceString(\"\"));")
+                out("var call" ++ auto_count ++ " = Grace_print(new GraceString(\"\"));")
             } else {
-                out("  var call" ++ auto_count ++ " = Grace_print(" ++ args.first ++ ");")
+                out("var call" ++ auto_count ++ " = Grace_print(" ++ args.first ++ ");")
             }
             o.register := "call" ++ auto_count
             auto_count := auto_count + 1
@@ -1281,6 +1318,7 @@ method compile(vl, of, mn, rm, bt, glpath) {
     }
     util.setline(1)
     out("function gracecode_" ++ modname ++ "() \{")
+    increaseindent
     if (util.extensions.contains("NativePrelude")) then {
         out("var Grace_prelude = window.Grace_native_prelude;")
     }
@@ -1297,18 +1335,19 @@ method compile(vl, of, mn, rm, bt, glpath) {
     for (values) do { o ->
         if (o.kind == "inherits") then {
             def sup = compilenode(o.value)
-            out("  this.superobj = {sup};")
-            out("  this.data = {sup}.data;")
-            out("  this._value = {sup}._value;")
+            out("this.superobj = {sup};")
+            out("this.data = {sup}.data;")
+            out("this._value = {sup}._value;")
         }
         if ((o.kind != "method") && (o.kind != "type")) then {
             compilenode(o)
         }
     }
     if (dialectHasAtModuleEnd) then {
-        out("  callmethod(Grace_prelude,\"atModuleEnd\", [1], this);")
+        out("callmethod(Grace_prelude,\"atModuleEnd\", [1], this);")
     }
-    out("  return this;")
+    out("return this;")
+    decreaseindent
     out("\}")
     xmodule.writeGCT(modname, modname ++ ".gct")
         fromValues(values)modules(staticmodules)
@@ -1318,7 +1357,7 @@ method compile(vl, of, mn, rm, bt, glpath) {
     out "  gctCache['{escapestring(modname)}'] = \"{escapestring(gctText)}\";"
     var lineOut := false
     for (output) do { o ->
-        if ("  lineNumber =" == o.substringFrom(0)to(14)) then {
+        if ("lineNumber =" == o.substringFrom(0)to(14)) then {
             lineOut := o
         } else {
             if (false != lineOut) then {


### PR DESCRIPTION
Currently the generated JavaScript doesn't really have consistent indentation, making it hard to read and debug.
I added two methods to `genjs.grace`: `increaseIndent` and `decreaseIndent` and modified `out` to include the indent, and the resulting generating code looks much nicer.
