### PR TITLE
Fix lexer losing indentation information for first line

### DIFF
--- a/lexer.grace
+++ b/lexer.grace
@@ -449,7 +449,7 @@ def LexerClass = object {
 
             method lexinput(input) {
                 var tokens := []
-                var mode := "n"
+                var mode := "d"
                 var newmode := mode
                 var instr := false
                 var inBackticks := false


### PR DESCRIPTION
Currently all tokens on the first line have an indentation of 0, even if the indentation is greater than 0.
