### PR TITLE
Apply ClassWrap transformation immediately

### DIFF
--- a/compiler.grace
+++ b/compiler.grace
@@ -53,6 +53,21 @@ if (util.target == "json") then {
 }
 
 var values := parser.parse(tokens)
+if (util.extensions.contains("ClassWrap")) then {
+    def vl = values
+    values := []
+    def inner = []
+    for (vl) do { v->
+        if ((v.kind == "import") || (v.kind == "dialect")) then {
+            values.push(v)
+        } else {
+            inner.push(v)
+        }
+    }
+    values.push(ast.methodNode.new(ast.identifierNode.new("new", false),
+        [ast.signaturePart.new("new")],
+        [ast.objectNode.new(inner, false)], false))
+}
 
 if (util.target == "parse") then {
     // Parse mode pretty-prints the source's AST and quits.

--- a/genc.grace
+++ b/genc.grace
@@ -1984,22 +1984,7 @@ method compile(vl, of, mn, rm, bt) {
     util.log_verbose "generating C code..."
     var argv := sys.argv
     var cmd
-    if (util.extensions.contains("ClassWrap")) then {
-        values := []
-        def inner = []
-        for (vl) do { v->
-            if ((v.kind == "import") || (v.kind == "dialect")) then {
-                values.push(v)
-            } else {
-                inner.push(v)
-            }
-        }
-        values.push(ast.methodNode.new(ast.identifierNode.new("new", false),
-            [ast.signaturePart.new("new")],
-            [ast.objectNode.new(inner, false)], false))
-    } else {
-        values := vl
-    }
+    values := vl
     var nummethods := 2 + countbindings(values)
     for (values) do { v->
         if (v.kind == "vardec") then {


### PR DESCRIPTION
This allows ClassWrap to work cross platform, as well as avoiding any pre-processing problems.
