### PR TITLE
Ensure dot is used in class declarations

### DIFF
--- a/parser.grace
+++ b/parser.grace
@@ -2415,6 +2415,13 @@ method doclass {
         }
         pushidentifier // A class currently cannot be anonymous
         def cname = values.pop
+        if (!accept("dot")) then {
+            def suggestion = errormessages.suggestion.new
+            suggestion.replaceToken(sym) with(".")
+            errormessages.syntaxError "A class must have a dot after the object name."
+                atPosition(lastToken.line, lastToken.linePos + lastToken.size + 1)
+                withSuggestion(suggestion)
+        }
         next
         var s := methodsignature(false)
         var csig := s.sig

--- a/tests/t140_classdot_fail_test.grace
+++ b/tests/t140_classdot_fail_test.grace
@@ -1,0 +1,1 @@
+class klass,new {}


### PR DESCRIPTION
The parser wasn't checking for a dot in the class name, so you could write anything there.
