### PR TITLE
Add object annotations, retained at runtime

### DIFF
--- a/ast.grace
+++ b/ast.grace
@@ -1049,6 +1049,7 @@ class objectNode.new(body, superclass') {
     def kind = "object"
     def value = body
     def superclass = superclass'
+    def annotations = collections.list.new
     var otype := false
     var classname := "object"
     var data := false
@@ -1056,6 +1057,9 @@ class objectNode.new(body, superclass') {
         if (visitor.visitObject(self)) then {
             if (self.superclass != false) then {
                 self.superclass.accept(visitor)
+            }
+            for (self.annotations) do { ann ->
+                ann.accept(visitor)
             }
             for (self.value) do { x ->
                 x.accept(visitor)
@@ -1069,6 +1073,8 @@ class objectNode.new(body, superclass') {
         blkBefore, blkAfter))
         n := blk.apply(n)
         n.line := line
+        n.annotations.extend(listMap(annotations, blk)
+            before(blkBefore) after(blkAfter))
         blkAfter.apply(n)
         n
     }

--- a/genc.grace
+++ b/genc.grace
@@ -434,6 +434,7 @@ method compileobject(o, outerRef) {
     var selfr := "obj" ++ myc
     var numFields := 1
     var numMethods := 0
+    var numAnnotations := o.annotations.size
     var pos := 1
     var superobj := false
     out "  Object inheritingObject{myc} = inheritingObject;"
@@ -458,8 +459,8 @@ method compileobject(o, outerRef) {
         numFields := 4
     }
     globals.push("static ClassData objclass{myc};");
-    out("  Object " ++ selfr ++ " = alloc_userobj2({numMethods},"
-        ++ "{numFields}, objclass{myc});")
+    out("  Object " ++ selfr ++ " = alloc_userobj3({numMethods}, "
+        ++ "{numFields}, {numAnnotations}, objclass{myc});")
     out("  gc_frame_newslot({selfr});")
     if (o.classname != "object") then {
         out("if (objclass{myc} == NULL) \{")
@@ -487,6 +488,10 @@ method compileobject(o, outerRef) {
     out "    lowerouter{myc} = (*(struct UserObject *)self).data[0];"
     out "    (*(struct UserObject *)self).data[0] = thisouter{myc};"
     out "  \}"
+    for (o.annotations.indices) do { i ->
+        def ann = compilenode(o.annotations.at(i))
+        out("  (*(struct UserObject *){selfr}).annotations[{i - 1}] = {ann};")
+    }
     for (o.value) do { e ->
         if (e.kind == "method") then {
             compilemethod(e, selfr, pos)

--- a/gracelib.c
+++ b/gracelib.c
@@ -3959,7 +3959,8 @@ void UserObj__release(struct UserObject *o) {
     glfree(o->data);
 }
 Object GraceDefaultObject;
-Object alloc_userobj2(int numMethods, int numFields, ClassData c) {
+Object alloc_userobj3(int numMethods, int numFields, int numAnnotations,
+      ClassData c) {
     if (GraceDefaultObject == NULL) {
         ClassData dc = alloc_class2("DefaultObject", 6,
                 (void*)&UserObj__mark);
@@ -3988,9 +3989,15 @@ Object alloc_userobj2(int numMethods, int numFields, ClassData c) {
     uo->data = glmalloc(sizeof(Object) * numFields);
     for (i=0; i<numFields; i++)
         uo->data[i] = NULL;
+    uo->annotations = numAnnotations > 0 ?
+        glmalloc(sizeof(Object) * numAnnotations) : NULL;
+    uo->numannotations = numAnnotations;
     uo->super = GraceDefaultObject;
     uo->ndata = numFields;
     return o;
+}
+Object alloc_userobj2(int numMethods, int numFields, ClassData c) {
+    return alloc_userobj3(numMethods, numFields, 0, c);
 }
 Object alloc_userobj(int numMethods, int numFields) {
     return alloc_userobj2(numMethods, numFields, NULL);

--- a/gracelib.h
+++ b/gracelib.h
@@ -54,7 +54,9 @@ struct UserObject {
     jmp_buf *retpoint;
     Object super;
     Object *data;
+    Object *annotations;
     int ndata;
+    int numannotations;
 };
 
 struct StackFrameObject {
@@ -117,6 +119,7 @@ ClassData alloc_class3(const char *, int, void(*)(void *), void(*)(void *));
 Object alloc_Type(const char *, int);
 Object alloc_userobj(int, int);
 Object alloc_userobj2(int, int, ClassData);
+Object alloc_userobj3(int, int, int, ClassData);
 Object alloc_obj2(int, int);
 Object* alloc_var();
 Object alloc_HashMapClassObject();

--- a/parser.grace
+++ b/parser.grace
@@ -2514,6 +2514,7 @@ method doobject {
         def localMinIndentLevel = minIndentLevel
         next
         var superclass := false
+        def anns = doannotation
         if(sym.kind != "lbrace") then {
             def suggestion = errormessages.suggestion.new
             def nextTok = findNextToken({ t -> t.kind == "rbrace" })
@@ -2573,6 +2574,9 @@ method doobject {
         }
         util.setline(btok.line)
         var o := ast.objectNode.new(body, superclass)
+        if (false != anns) then {
+            o.annotations.extend(anns)
+        }
         values.push(o)
         minIndentLevel := localMinIndentLevel
     }


### PR DESCRIPTION
Annotations can now be placed on object constructors with the syntax
'object is ... {} ', and the annotation objects will be stored in the
object's internal structure. They can be retrieved using the mirrors
module and the 'annotations' method.
